### PR TITLE
[libjpeg-turbo] enable jpeg_mem_src/dest

### DIFF
--- a/rpm/libjpeg-turbo.spec
+++ b/rpm/libjpeg-turbo.spec
@@ -66,8 +66,7 @@ Man pages and developer documentation for %{name}.
 
 %build
 %{cmake} -DBUILD="$(sed 's/+.*//' <<<"%{version}")" \
-         -DWITH_SIMD=0 \
-         -DWITH_MEM_SRCDST=0 .
+         -DWITH_SIMD=0 .
 
 %make_build
 


### PR DESCRIPTION
You'll need this for any significant update to Poppler (21.12.0 and onwards).
Sure, this is a bit iffy library-versioning-wise, but i can't see that it actually _breaks_ anything and all the cool kids are doing it.
But then again, C/C++ is not my day job.